### PR TITLE
Replace usage of fill_parent with match_parent

### DIFF
--- a/res/layout/browse_row.xml
+++ b/res/layout/browse_row.xml
@@ -37,7 +37,7 @@
 
         <LinearLayout
             android:id="@+id/text_container"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
             android:layout_toLeftOf="@+id/menu"
@@ -47,7 +47,7 @@
 
             <TextView
                 android:id="@+id/textView1"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:maxLines="2"
@@ -56,7 +56,7 @@
 
             <TextView
                 android:id="@+id/textView2"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"
                 android:ellipsize="end"

--- a/res/layout/player_activity.xml
+++ b/res/layout/player_activity.xml
@@ -22,7 +22,7 @@
 
     <fragment
         android:id="@+id/cast_mini_controller"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         app:castShowImageThumbnail="true"
@@ -48,8 +48,8 @@
 
         <ImageView
             android:id="@+id/coverArtView"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:scaleType="fitXY"
             android:visibility="gone" />
 
@@ -86,7 +86,7 @@
 
         <RelativeLayout
             android:id="@+id/control_bar"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="45dp"
             android:layout_alignParentBottom="true" >
 
@@ -100,7 +100,7 @@
             <TextView
                 android:id="@+id/startText"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_marginLeft="5dp"
                 android:layout_toRightOf="@+id/playPauseImageView"
                 android:gravity="center_vertical"
@@ -111,7 +111,7 @@
             <TextView
                 android:id="@+id/endText"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_alignParentRight="true"
                 android:layout_marginRight="16dp"
                 android:gravity="center_vertical"
@@ -121,7 +121,7 @@
 
             <SeekBar
                 android:id="@+id/seekBar1"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_gravity="center"
@@ -135,7 +135,7 @@
 
     <TextView
         android:id="@+id/titleTextView"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_below="@+id/videoView1"
@@ -147,7 +147,7 @@
 
     <TextView
         android:id="@+id/authorTextView"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignLeft="@+id/titleTextView"
         android:layout_alignRight="@+id/titleTextView"
@@ -158,7 +158,7 @@
 
     <TextView
         android:id="@+id/descriptionTextView"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@+id/cast_mini_controller"
         android:layout_alignLeft="@+id/titleTextView"

--- a/res/layout/queue_activity.xml
+++ b/res/layout/queue_activity.xml
@@ -16,8 +16,8 @@
   -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent" >
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" >
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
@@ -29,8 +29,8 @@
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
     <RelativeLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_below="@+id/toolbar"
         android:layout_alignParentBottom="true"
         android:id="@+id/container" />

--- a/res/layout/queue_row.xml
+++ b/res/layout/queue_row.xml
@@ -21,7 +21,7 @@
     android:foreground="?selectableItemBackground"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" >
-    <View android:layout_width="fill_parent" android:layout_height="fill_parent"
+    <View android:layout_width="match_parent" android:layout_height="match_parent"
           android:background="@drawable/bg_swipe_item_right" />
 
     <RelativeLayout
@@ -118,7 +118,7 @@
 
             <TextView
                 android:id="@+id/textView2"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"
                 android:ellipsize="end"
@@ -130,7 +130,7 @@
 
         <View
             android:layout_alignParentBottom="true"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_toRightOf="@+id/imageView1"
             android:background="@drawable/vertical_divider" />

--- a/res/layout/video_browser.xml
+++ b/res/layout/video_browser.xml
@@ -40,7 +40,7 @@
 
     <fragment
         android:id="@+id/cast_mini_controller"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:visibility="gone"

--- a/res/layout/video_browser_fragment.xml
+++ b/res/layout/video_browser_fragment.xml
@@ -21,8 +21,8 @@
     <android.support.v7.widget.RecyclerView
         android:id="@+id/list"
         android:scrollbars="vertical"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
     <ProgressBar
         android:id="@+id/progress_indicator"


### PR DESCRIPTION
fill_parent was deprecated in API level 8
https://developer.android.com/reference/android/view/ViewGroup.LayoutParams.html#FILL_PARENT