### PR TITLE
Drop m prefix convention

### DIFF
--- a/src/com/google/sample/cast/refplayer/CastOptionsProvider.java
+++ b/src/com/google/sample/cast/refplayer/CastOptionsProvider.java
@@ -34,7 +34,9 @@ import java.util.List;
 
 /**
  * Implements {@link OptionsProvider} to provide {@link CastOptions}.
+ * This class is designated in AndroidManifest.xml. It's instantiation is handled by the SDK.
  */
+@SuppressWarnings("unused")
 public class CastOptionsProvider implements OptionsProvider {
 
     @Override

--- a/src/com/google/sample/cast/refplayer/VideoBrowserActivity.java
+++ b/src/com/google/sample/cast/refplayer/VideoBrowserActivity.java
@@ -32,7 +32,6 @@ import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -43,35 +42,35 @@ import android.view.MenuItem;
 public class VideoBrowserActivity extends AppCompatActivity {
 
     private static final String TAG = "VideoBrowserActivity";
-    private CastContext mCastContext;
-    private final SessionManagerListener<CastSession> mSessionManagerListener =
+    private CastContext castContext;
+    private final SessionManagerListener<CastSession> sessionManagerListener =
             new MySessionManagerListener();
-    private CastSession mCastSession;
+    private CastSession castSession;
     private MenuItem mediaRouteMenuItem;
-    private MenuItem mQueueMenuItem;
-    private Toolbar mToolbar;
-    private IntroductoryOverlay mIntroductoryOverlay;
-    private CastStateListener mCastStateListener;
+    private MenuItem queueMenuItem;
+    private Toolbar toolbar;
+    private IntroductoryOverlay introductoryOverlay;
+    private CastStateListener castStateListener;
 
     private class MySessionManagerListener implements SessionManagerListener<CastSession> {
 
         @Override
         public void onSessionEnded(CastSession session, int error) {
-            if (session == mCastSession) {
-                mCastSession = null;
+            if (session == castSession) {
+                castSession = null;
             }
             invalidateOptionsMenu();
         }
 
         @Override
         public void onSessionResumed(CastSession session, boolean wasSuspended) {
-            mCastSession = session;
+            castSession = session;
             invalidateOptionsMenu();
         }
 
         @Override
         public void onSessionStarted(CastSession session, String sessionId) {
-            mCastSession = session;
+            castSession = session;
             invalidateOptionsMenu();
         }
 
@@ -111,7 +110,7 @@ public class VideoBrowserActivity extends AppCompatActivity {
         setContentView(R.layout.video_browser);
         setupActionBar();
 
-        mCastStateListener = new CastStateListener() {
+        castStateListener = new CastStateListener() {
             @Override
             public void onCastStateChanged(int newState) {
                 if (newState != CastState.NO_DEVICES_AVAILABLE) {
@@ -119,13 +118,13 @@ public class VideoBrowserActivity extends AppCompatActivity {
                 }
             }
         };
-        mCastContext = CastContext.getSharedInstance(this);
-        mCastContext.registerLifecycleCallbacksBeforeIceCreamSandwich(this, savedInstanceState);
+        castContext = CastContext.getSharedInstance(this);
+        castContext.registerLifecycleCallbacksBeforeIceCreamSandwich(this, savedInstanceState);
     }
 
     private void setupActionBar() {
-        mToolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(mToolbar);
+        toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
     }
 
     @Override
@@ -134,7 +133,7 @@ public class VideoBrowserActivity extends AppCompatActivity {
         getMenuInflater().inflate(R.menu.browse, menu);
         mediaRouteMenuItem = CastButtonFactory.setUpMediaRouteButton(getApplicationContext(), menu,
                 R.id.media_route_menu_item);
-        mQueueMenuItem = menu.findItem(R.id.action_show_queue);
+        queueMenuItem = menu.findItem(R.id.action_show_queue);
         showIntroductoryOverlay();
         return true;
     }
@@ -142,7 +141,7 @@ public class VideoBrowserActivity extends AppCompatActivity {
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         menu.findItem(R.id.action_show_queue).setVisible(
-                (mCastSession != null) && mCastSession.isConnected());
+                (castSession != null) && castSession.isConnected());
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -161,43 +160,43 @@ public class VideoBrowserActivity extends AppCompatActivity {
 
     @Override
     public boolean dispatchKeyEvent(@NonNull KeyEvent event) {
-        return mCastContext.onDispatchVolumeKeyEventBeforeJellyBean(event)
+        return castContext.onDispatchVolumeKeyEventBeforeJellyBean(event)
                 || super.dispatchKeyEvent(event);
     }
 
     @Override
     protected void onResume() {
-        mCastContext.addCastStateListener(mCastStateListener);
-        mCastContext.getSessionManager().addSessionManagerListener(
-                mSessionManagerListener, CastSession.class);
-        if (mCastSession == null) {
-            mCastSession = CastContext.getSharedInstance(this).getSessionManager()
+        castContext.addCastStateListener(castStateListener);
+        castContext.getSessionManager().addSessionManagerListener(
+                sessionManagerListener, CastSession.class);
+        if (castSession == null) {
+            castSession = CastContext.getSharedInstance(this).getSessionManager()
                     .getCurrentCastSession();
         }
-        if (mQueueMenuItem != null) {
-            mQueueMenuItem.setVisible(
-                    (mCastSession != null) && mCastSession.isConnected());
+        if (queueMenuItem != null) {
+            queueMenuItem.setVisible(
+                    (castSession != null) && castSession.isConnected());
         }
         super.onResume();
     }
 
     @Override
     protected void onPause() {
-        mCastContext.removeCastStateListener(mCastStateListener);
-        mCastContext.getSessionManager().removeSessionManagerListener(
-                mSessionManagerListener, CastSession.class);
+        castContext.removeCastStateListener(castStateListener);
+        castContext.getSessionManager().removeSessionManagerListener(
+                sessionManagerListener, CastSession.class);
         super.onPause();
     }
 
     private void showIntroductoryOverlay() {
-        if (mIntroductoryOverlay != null) {
-            mIntroductoryOverlay.remove();
+        if (introductoryOverlay != null) {
+            introductoryOverlay.remove();
         }
         if ((mediaRouteMenuItem != null) && mediaRouteMenuItem.isVisible()) {
             new Handler().post(new Runnable() {
                 @Override
                 public void run() {
-                    mIntroductoryOverlay = new IntroductoryOverlay.Builder(
+                    introductoryOverlay = new IntroductoryOverlay.Builder(
                             VideoBrowserActivity.this, mediaRouteMenuItem)
                             .setTitleText(getString(R.string.introducing_cast))
                             .setOverlayColor(R.color.primary)
@@ -206,11 +205,11 @@ public class VideoBrowserActivity extends AppCompatActivity {
                                     new IntroductoryOverlay.OnOverlayDismissedListener() {
                                         @Override
                                         public void onOverlayDismissed() {
-                                            mIntroductoryOverlay = null;
+                                            introductoryOverlay = null;
                                         }
                                     })
                             .build();
-                    mIntroductoryOverlay.show();
+                    introductoryOverlay.show();
                 }
             });
         }

--- a/src/com/google/sample/cast/refplayer/browser/VideoBrowserFragment.java
+++ b/src/com/google/sample/cast/refplayer/browser/VideoBrowserFragment.java
@@ -51,11 +51,11 @@ public class VideoBrowserFragment extends Fragment implements VideoListAdapter.I
     private static final String TAG = "VideoBrowserFragment";
     private static final String CATALOG_URL =
             "https://commondatastorage.googleapis.com/gtv-videos-bucket/CastVideos/f.json";
-    private RecyclerView mRecyclerView;
-    private VideoListAdapter mAdapter;
-    private View mEmptyView;
-    private View mLoadingView;
-    private final SessionManagerListener<CastSession> mSessionManagerListener =
+    private RecyclerView recyclerView;
+    private VideoListAdapter adapter;
+    private View emptyView;
+    private View loadingView;
+    private final SessionManagerListener<CastSession> sessionManagerListener =
             new MySessionManagerListener();
 
     public VideoBrowserFragment() {
@@ -70,14 +70,14 @@ public class VideoBrowserFragment extends Fragment implements VideoListAdapter.I
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        mRecyclerView = (RecyclerView) getView().findViewById(R.id.list);
-        mEmptyView = getView().findViewById(R.id.empty_view);
-        mLoadingView = getView().findViewById(R.id.progress_indicator);
+        recyclerView = (RecyclerView) getView().findViewById(R.id.list);
+        emptyView = getView().findViewById(R.id.empty_view);
+        loadingView = getView().findViewById(R.id.progress_indicator);
         LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
         layoutManager.setOrientation(LinearLayoutManager.VERTICAL);
-        mRecyclerView.setLayoutManager(layoutManager);
-        mAdapter = new VideoListAdapter(this, getContext());
-        mRecyclerView.setAdapter(mAdapter);
+        recyclerView.setLayoutManager(layoutManager);
+        adapter = new VideoListAdapter(this, getContext());
+        recyclerView.setAdapter(adapter);
         getLoaderManager().initLoader(0, null, this);
     }
 
@@ -88,7 +88,7 @@ public class VideoBrowserFragment extends Fragment implements VideoListAdapter.I
         } else {
             String transitionName = getString(R.string.transition_image);
             VideoListAdapter.ViewHolder viewHolder =
-                    (VideoListAdapter.ViewHolder) mRecyclerView.findViewHolderForPosition(position);
+                    (VideoListAdapter.ViewHolder) recyclerView.findViewHolderForPosition(position);
             Pair<View, String> imagePair = Pair
                     .create((View) viewHolder.getImageView(), transitionName);
             ActivityOptionsCompat options = ActivityOptionsCompat
@@ -108,27 +108,27 @@ public class VideoBrowserFragment extends Fragment implements VideoListAdapter.I
 
     @Override
     public void onLoadFinished(Loader<List<MediaInfo>> loader, List<MediaInfo> data) {
-        mAdapter.setData(data);
-        mLoadingView.setVisibility(View.GONE);
-        mEmptyView.setVisibility(null == data || data.isEmpty() ? View.VISIBLE : View.GONE);
+        adapter.setData(data);
+        loadingView.setVisibility(View.GONE);
+        emptyView.setVisibility(null == data || data.isEmpty() ? View.VISIBLE : View.GONE);
     }
 
     @Override
     public void onLoaderReset(Loader<List<MediaInfo>> loader) {
-        mAdapter.setData(null);
+        adapter.setData(null);
     }
 
     @Override
     public void onStart() {
         CastContext.getSharedInstance(getContext()).getSessionManager()
-                .addSessionManagerListener(mSessionManagerListener, CastSession.class);
+                .addSessionManagerListener(sessionManagerListener, CastSession.class);
         super.onStart();
     }
 
     @Override
     public void onStop() {
         CastContext.getSharedInstance(getContext()).getSessionManager()
-                .removeSessionManagerListener(mSessionManagerListener, CastSession.class);
+                .removeSessionManagerListener(sessionManagerListener, CastSession.class);
         super.onStop();
     }
 
@@ -136,17 +136,17 @@ public class VideoBrowserFragment extends Fragment implements VideoListAdapter.I
 
         @Override
         public void onSessionEnded(CastSession session, int error) {
-            mAdapter.notifyDataSetChanged();
+            adapter.notifyDataSetChanged();
         }
 
         @Override
         public void onSessionResumed(CastSession session, boolean wasSuspended) {
-            mAdapter.notifyDataSetChanged();
+            adapter.notifyDataSetChanged();
         }
 
         @Override
         public void onSessionStarted(CastSession session, String sessionId) {
-            mAdapter.notifyDataSetChanged();
+            adapter.notifyDataSetChanged();
         }
 
         @Override

--- a/src/com/google/sample/cast/refplayer/browser/VideoItemLoader.java
+++ b/src/com/google/sample/cast/refplayer/browser/VideoItemLoader.java
@@ -30,17 +30,17 @@ import java.util.List;
 public class VideoItemLoader extends AsyncTaskLoader<List<MediaInfo>> {
 
     private static final String TAG = "VideoItemLoader";
-    private final String mUrl;
+    private final String url;
 
     public VideoItemLoader(Context context, String url) {
         super(context);
-        this.mUrl = url;
+        this.url = url;
     }
 
     @Override
     public List<MediaInfo> loadInBackground() {
         try {
-            return VideoProvider.buildMedia(mUrl);
+            return VideoProvider.buildMedia(url);
         } catch (Exception e) {
             Log.e(TAG, "Failed to fetch media data", e);
             return null;

--- a/src/com/google/sample/cast/refplayer/browser/VideoListAdapter.java
+++ b/src/com/google/sample/cast/refplayer/browser/VideoListAdapter.java
@@ -41,13 +41,13 @@ import java.util.List;
 public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.ViewHolder> {
 
     private static final float ASPECT_RATIO = 9f / 16f;
-    private final ItemClickListener mClickListener;
-    private final Context mAppContext;
+    private final ItemClickListener clickListener;
+    private final Context appContext;
     private List<MediaInfo> videos;
 
     public VideoListAdapter(ItemClickListener clickListener, Context context) {
-        mClickListener = clickListener;
-        mAppContext = context.getApplicationContext();
+        this.clickListener = clickListener;
+        appContext = context.getApplicationContext();
     }
 
     @Override
@@ -68,23 +68,23 @@ public class VideoListAdapter extends RecyclerView.Adapter<VideoListAdapter.View
         viewHolder.mMenu.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mClickListener.itemClicked(view, item, position);
+                clickListener.itemClicked(view, item, position);
             }
         });
         viewHolder.mImgView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mClickListener.itemClicked(view, item, position);
+                clickListener.itemClicked(view, item, position);
             }
         });
 
         viewHolder.mTextContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mClickListener.itemClicked(view, item, position);
+                clickListener.itemClicked(view, item, position);
             }
         });
-        CastSession castSession = CastContext.getSharedInstance(mAppContext).getSessionManager()
+        CastSession castSession = CastContext.getSharedInstance(appContext).getSessionManager()
                 .getCurrentCastSession();
         viewHolder.mMenu.setVisibility(
                 (castSession != null && castSession.isConnected()) ? View.VISIBLE : View.GONE);

--- a/src/com/google/sample/cast/refplayer/mediaplayer/LocalPlayerActivity.java
+++ b/src/com/google/sample/cast/refplayer/mediaplayer/LocalPlayerActivity.java
@@ -78,33 +78,33 @@ import java.util.TimerTask;
 public class LocalPlayerActivity extends AppCompatActivity {
 
     private static final String TAG = "LocalPlayerActivity";
-    private VideoView mVideoView;
-    private TextView mTitleView;
-    private TextView mDescriptionView;
-    private TextView mStartText;
-    private TextView mEndText;
-    private SeekBar mSeekbar;
-    private ImageView mPlayPause;
-    private ProgressBar mLoading;
-    private View mControllers;
-    private View mContainer;
-    private ImageView mCoverArt;
-    private Timer mSeekbarTimer;
-    private Timer mControllersTimer;
-    private PlaybackLocation mLocation;
-    private PlaybackState mPlaybackState;
-    private final Handler mHandler = new Handler();
-    private final float mAspectRatio = 72f / 128;
-    private AQuery mAquery;
-    private MediaInfo mSelectedMedia;
-    private boolean mControllersVisible;
-    private int mDuration;
-    private TextView mAuthorView;
-    private ImageButton mPlayCircle;
-    private CastContext mCastContext;
-    private CastSession mCastSession;
-    private SessionManagerListener<CastSession> mSessionManagerListener;
-    private MenuItem mQueueMenuItem;
+    private VideoView videoView;
+    private TextView titleView;
+    private TextView descriptionView;
+    private TextView startText;
+    private TextView endText;
+    private SeekBar seekBar;
+    private ImageView playPause;
+    private ProgressBar loading;
+    private View controllers;
+    private View container;
+    private ImageView coverArt;
+    private Timer seekBarTimer;
+    private Timer controllersTimer;
+    private PlaybackLocation location;
+    private PlaybackState playbackState;
+    private final Handler handler = new Handler();
+    private final float aspectRatio = 72f / 128;
+    private AQuery androidQuery;
+    private MediaInfo selectedMedia;
+    private boolean controllersVisible;
+    private int duration;
+    private TextView authorView;
+    private ImageButton playCircle;
+    private CastContext castContext;
+    private CastSession castSession;
+    private SessionManagerListener<CastSession> sessionManagerListener;
+    private MenuItem queueMenuItem;
 
     /**
      * indicates whether we are doing a local or a remote playback
@@ -125,52 +125,52 @@ public class LocalPlayerActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.player_activity);
-        mAquery = new AQuery(this);
+        androidQuery = new AQuery(this);
         loadViews();
         setupControlsCallbacks();
         setupCastListener();
-        mCastContext = CastContext.getSharedInstance(this);
-        mCastContext.registerLifecycleCallbacksBeforeIceCreamSandwich(this, savedInstanceState);
-        mCastSession = mCastContext.getSessionManager().getCurrentCastSession();
+        castContext = CastContext.getSharedInstance(this);
+        castContext.registerLifecycleCallbacksBeforeIceCreamSandwich(this, savedInstanceState);
+        castSession = castContext.getSessionManager().getCurrentCastSession();
         // see what we need to play and where
         Bundle bundle = getIntent().getExtras();
         if (bundle != null) {
-            mSelectedMedia = getIntent().getParcelableExtra("media");
+            selectedMedia = getIntent().getParcelableExtra("media");
             setupActionBar();
             boolean shouldStartPlayback = bundle.getBoolean("shouldStart");
             int startPosition = bundle.getInt("startPosition", 0);
-            mVideoView.setVideoURI(Uri.parse(mSelectedMedia.getContentId()));
-            Log.d(TAG, "Setting url of the VideoView to: " + mSelectedMedia.getContentId());
+            videoView.setVideoURI(Uri.parse(selectedMedia.getContentId()));
+            Log.d(TAG, "Setting url of the VideoView to: " + selectedMedia.getContentId());
             if (shouldStartPlayback) {
                 // this will be the case only if we are coming from the
                 // CastControllerActivity by disconnecting from a device
-                mPlaybackState = PlaybackState.PLAYING;
+                playbackState = PlaybackState.PLAYING;
                 updatePlaybackLocation(PlaybackLocation.LOCAL);
-                updatePlayButton(mPlaybackState);
+                updatePlayButton(playbackState);
                 if (startPosition > 0) {
-                    mVideoView.seekTo(startPosition);
+                    videoView.seekTo(startPosition);
                 }
-                mVideoView.start();
+                videoView.start();
                 startControllersTimer();
             } else {
                 // we should load the video but pause it
                 // and show the album art.
-                if (mCastSession != null && mCastSession.isConnected()) {
+                if (castSession != null && castSession.isConnected()) {
                     updatePlaybackLocation(PlaybackLocation.REMOTE);
                 } else {
                     updatePlaybackLocation(PlaybackLocation.LOCAL);
                 }
-                mPlaybackState = PlaybackState.IDLE;
-                updatePlayButton(mPlaybackState);
+                playbackState = PlaybackState.IDLE;
+                updatePlayButton(playbackState);
             }
         }
-        if (mTitleView != null) {
+        if (titleView != null) {
             updateMetadata(true);
         }
     }
 
     private void setupCastListener() {
-        mSessionManagerListener = new SessionManagerListener<CastSession>() {
+        sessionManagerListener = new SessionManagerListener<CastSession>() {
 
             @Override
             public void onSessionEnded(CastSession session, int error) {
@@ -214,61 +214,61 @@ public class LocalPlayerActivity extends AppCompatActivity {
             }
 
             private void onApplicationConnected(CastSession castSession) {
-                mCastSession = castSession;
-                if (null != mSelectedMedia) {
+                LocalPlayerActivity.this.castSession = castSession;
+                if (null != selectedMedia) {
 
-                    if (mPlaybackState == PlaybackState.PLAYING) {
-                        mVideoView.pause();
-                        loadRemoteMedia(mSeekbar.getProgress(), true);
+                    if (playbackState == PlaybackState.PLAYING) {
+                        videoView.pause();
+                        loadRemoteMedia(seekBar.getProgress(), true);
                         return;
                     } else {
-                        mPlaybackState = PlaybackState.IDLE;
+                        playbackState = PlaybackState.IDLE;
                         updatePlaybackLocation(PlaybackLocation.REMOTE);
                     }
                 }
-                updatePlayButton(mPlaybackState);
+                updatePlayButton(playbackState);
                 invalidateOptionsMenu();
             }
 
             private void onApplicationDisconnected() {
                 updatePlaybackLocation(PlaybackLocation.LOCAL);
-                mPlaybackState = PlaybackState.IDLE;
-                mLocation = PlaybackLocation.LOCAL;
-                updatePlayButton(mPlaybackState);
+                playbackState = PlaybackState.IDLE;
+                location = PlaybackLocation.LOCAL;
+                updatePlayButton(playbackState);
                 invalidateOptionsMenu();
             }
         };
     }
 
     private void updatePlaybackLocation(PlaybackLocation location) {
-        mLocation = location;
+        this.location = location;
         if (location == PlaybackLocation.LOCAL) {
-            if (mPlaybackState == PlaybackState.PLAYING
-                    || mPlaybackState == PlaybackState.BUFFERING) {
+            if (playbackState == PlaybackState.PLAYING
+                    || playbackState == PlaybackState.BUFFERING) {
                 setCoverArtStatus(null);
                 startControllersTimer();
             } else {
                 stopControllersTimer();
-                setCoverArtStatus(MediaUtils.getImageUrl(mSelectedMedia, 0));
+                setCoverArtStatus(MediaUtils.getImageUrl(selectedMedia, 0));
             }
         } else {
             stopControllersTimer();
-            setCoverArtStatus(MediaUtils.getImageUrl(mSelectedMedia, 0));
+            setCoverArtStatus(MediaUtils.getImageUrl(selectedMedia, 0));
             updateControllersVisibility(false);
         }
     }
 
     private void play(int position) {
         startControllersTimer();
-        switch (mLocation) {
+        switch (location) {
             case LOCAL:
-                mVideoView.seekTo(position);
-                mVideoView.start();
+                videoView.seekTo(position);
+                videoView.start();
                 break;
             case REMOTE:
-                mPlaybackState = PlaybackState.BUFFERING;
-                updatePlayButton(mPlaybackState);
-                mCastSession.getRemoteMediaClient().seek(position);
+                playbackState = PlaybackState.BUFFERING;
+                updatePlayButton(playbackState);
+                castSession.getRemoteMediaClient().seek(position);
                 break;
             default:
                 break;
@@ -278,13 +278,13 @@ public class LocalPlayerActivity extends AppCompatActivity {
 
     private void togglePlayback() {
         stopControllersTimer();
-        switch (mPlaybackState) {
+        switch (playbackState) {
             case PAUSED:
-                switch (mLocation) {
+                switch (location) {
                     case LOCAL:
-                        mVideoView.start();
+                        videoView.start();
                         Log.d(TAG, "Playing locally...");
-                        mPlaybackState = PlaybackState.PLAYING;
+                        playbackState = PlaybackState.PLAYING;
                         startControllersTimer();
                         restartTrickplayTimer();
                         updatePlaybackLocation(PlaybackLocation.LOCAL);
@@ -299,23 +299,23 @@ public class LocalPlayerActivity extends AppCompatActivity {
                 break;
 
             case PLAYING:
-                mPlaybackState = PlaybackState.PAUSED;
-                mVideoView.pause();
+                playbackState = PlaybackState.PAUSED;
+                videoView.pause();
                 break;
 
             case IDLE:
-                switch (mLocation) {
+                switch (location) {
                     case LOCAL:
-                        mVideoView.setVideoURI(Uri.parse(mSelectedMedia.getContentId()));
-                        mVideoView.seekTo(0);
-                        mVideoView.start();
-                        mPlaybackState = PlaybackState.PLAYING;
+                        videoView.setVideoURI(Uri.parse(selectedMedia.getContentId()));
+                        videoView.seekTo(0);
+                        videoView.start();
+                        playbackState = PlaybackState.PLAYING;
                         restartTrickplayTimer();
                         updatePlaybackLocation(PlaybackLocation.LOCAL);
                         break;
                     case REMOTE:
-                        if (mCastSession != null && mCastSession.isConnected()) {
-                            Utils.showQueuePopup(this, mPlayCircle, mSelectedMedia);
+                        if (castSession != null && castSession.isConnected()) {
+                            Utils.showQueuePopup(this, playCircle, selectedMedia);
                         }
                         break;
                     default:
@@ -325,14 +325,14 @@ public class LocalPlayerActivity extends AppCompatActivity {
             default:
                 break;
         }
-        updatePlayButton(mPlaybackState);
+        updatePlayButton(playbackState);
     }
 
     private void loadRemoteMedia(int position, boolean autoPlay) {
-        if (mCastSession == null) {
+        if (castSession == null) {
             return;
         }
-        final RemoteMediaClient remoteMediaClient = mCastSession.getRemoteMediaClient();
+        final RemoteMediaClient remoteMediaClient = castSession.getRemoteMediaClient();
         if (remoteMediaClient == null) {
             return;
         }
@@ -360,61 +360,61 @@ public class LocalPlayerActivity extends AppCompatActivity {
             public void onSendingRemoteMediaRequest() {
             }
         });
-        remoteMediaClient.load(mSelectedMedia, autoPlay, position);
+        remoteMediaClient.load(selectedMedia, autoPlay, position);
     }
 
     private void setCoverArtStatus(String url) {
         if (url != null) {
-            mAquery.id(mCoverArt).image(url);
-            mCoverArt.setVisibility(View.VISIBLE);
-            mVideoView.setVisibility(View.INVISIBLE);
+            androidQuery.id(coverArt).image(url);
+            coverArt.setVisibility(View.VISIBLE);
+            videoView.setVisibility(View.INVISIBLE);
         } else {
-            mCoverArt.setVisibility(View.GONE);
-            mVideoView.setVisibility(View.VISIBLE);
+            coverArt.setVisibility(View.GONE);
+            videoView.setVisibility(View.VISIBLE);
         }
     }
 
     private void stopTrickplayTimer() {
         Log.d(TAG, "Stopped TrickPlay Timer");
-        if (mSeekbarTimer != null) {
-            mSeekbarTimer.cancel();
+        if (seekBarTimer != null) {
+            seekBarTimer.cancel();
         }
     }
 
     private void restartTrickplayTimer() {
         stopTrickplayTimer();
-        mSeekbarTimer = new Timer();
-        mSeekbarTimer.scheduleAtFixedRate(new UpdateSeekbarTask(), 100, 1000);
+        seekBarTimer = new Timer();
+        seekBarTimer.scheduleAtFixedRate(new UpdateSeekbarTask(), 100, 1000);
         Log.d(TAG, "Restarted TrickPlay Timer");
     }
 
     private void stopControllersTimer() {
-        if (mControllersTimer != null) {
-            mControllersTimer.cancel();
+        if (controllersTimer != null) {
+            controllersTimer.cancel();
         }
     }
 
     private void startControllersTimer() {
-        if (mControllersTimer != null) {
-            mControllersTimer.cancel();
+        if (controllersTimer != null) {
+            controllersTimer.cancel();
         }
-        if (mLocation == PlaybackLocation.REMOTE) {
+        if (location == PlaybackLocation.REMOTE) {
             return;
         }
-        mControllersTimer = new Timer();
-        mControllersTimer.schedule(new HideControllersTask(), 5000);
+        controllersTimer = new Timer();
+        controllersTimer.schedule(new HideControllersTask(), 5000);
     }
 
     // should be called from the main thread
     private void updateControllersVisibility(boolean show) {
         if (show) {
             getSupportActionBar().show();
-            mControllers.setVisibility(View.VISIBLE);
+            controllers.setVisibility(View.VISIBLE);
         } else {
             if (!Utils.isOrientationPortrait(this)) {
                 getSupportActionBar().hide();
             }
-            mControllers.setVisibility(View.INVISIBLE);
+            controllers.setVisibility(View.INVISIBLE);
         }
     }
 
@@ -422,23 +422,23 @@ public class LocalPlayerActivity extends AppCompatActivity {
     protected void onPause() {
         super.onPause();
         Log.d(TAG, "onPause() was called");
-        if (mLocation == PlaybackLocation.LOCAL) {
+        if (location == PlaybackLocation.LOCAL) {
 
-            if (mSeekbarTimer != null) {
-                mSeekbarTimer.cancel();
-                mSeekbarTimer = null;
+            if (seekBarTimer != null) {
+                seekBarTimer.cancel();
+                seekBarTimer = null;
             }
-            if (mControllersTimer != null) {
-                mControllersTimer.cancel();
+            if (controllersTimer != null) {
+                controllersTimer.cancel();
             }
             // since we are playing locally, we need to stop the playback of
             // video (if user is not watching, pause it!)
-            mVideoView.pause();
-            mPlaybackState = PlaybackState.PAUSED;
+            videoView.pause();
+            playbackState = PlaybackState.PAUSED;
             updatePlayButton(PlaybackState.PAUSED);
         }
-        mCastContext.getSessionManager().removeSessionManagerListener(
-                mSessionManagerListener, CastSession.class);
+        castContext.getSessionManager().removeSessionManagerListener(
+                sessionManagerListener, CastSession.class);
     }
 
     @Override
@@ -464,23 +464,23 @@ public class LocalPlayerActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         Log.d(TAG, "onResume() was called");
-        mCastContext.getSessionManager().addSessionManagerListener(
-                mSessionManagerListener, CastSession.class);
-        if (mCastSession != null && mCastSession.isConnected()) {
+        castContext.getSessionManager().addSessionManagerListener(
+                sessionManagerListener, CastSession.class);
+        if (castSession != null && castSession.isConnected()) {
             updatePlaybackLocation(PlaybackLocation.REMOTE);
         } else {
             updatePlaybackLocation(PlaybackLocation.LOCAL);
         }
-        if (mQueueMenuItem != null) {
-            mQueueMenuItem.setVisible(
-                    (mCastSession != null) && mCastSession.isConnected());
+        if (queueMenuItem != null) {
+            queueMenuItem.setVisible(
+                    (castSession != null) && castSession.isConnected());
         }
         super.onResume();
     }
 
     @Override
     public boolean dispatchKeyEvent(@NonNull KeyEvent event) {
-        return mCastContext.onDispatchVolumeKeyEventBeforeJellyBean(event)
+        return castContext.onDispatchVolumeKeyEventBeforeJellyBean(event)
                 || super.dispatchKeyEvent(event);
     }
 
@@ -488,11 +488,11 @@ public class LocalPlayerActivity extends AppCompatActivity {
 
         @Override
         public void run() {
-            mHandler.post(new Runnable() {
+            handler.post(new Runnable() {
                 @Override
                 public void run() {
                     updateControllersVisibility(false);
-                    mControllersVisible = false;
+                    controllersVisible = false;
                 }
             });
 
@@ -503,13 +503,13 @@ public class LocalPlayerActivity extends AppCompatActivity {
 
         @Override
         public void run() {
-            mHandler.post(new Runnable() {
+            handler.post(new Runnable() {
 
                 @Override
                 public void run() {
-                    if (mLocation == PlaybackLocation.LOCAL) {
-                        int currentPos = mVideoView.getCurrentPosition();
-                        updateSeekbar(currentPos, mDuration);
+                    if (location == PlaybackLocation.LOCAL) {
+                        int currentPos = videoView.getCurrentPosition();
+                        updateSeekbar(currentPos, duration);
                     }
                 }
             });
@@ -517,7 +517,7 @@ public class LocalPlayerActivity extends AppCompatActivity {
     }
 
     private void setupControlsCallbacks() {
-        mVideoView.setOnErrorListener(new OnErrorListener() {
+        videoView.setOnErrorListener(new OnErrorListener() {
 
             @Override
             public boolean onError(MediaPlayer mp, int what, int extra) {
@@ -532,41 +532,41 @@ public class LocalPlayerActivity extends AppCompatActivity {
                     msg = getString(R.string.video_error_unknown_error);
                 }
                 Utils.showErrorDialog(LocalPlayerActivity.this, msg);
-                mVideoView.stopPlayback();
-                mPlaybackState = PlaybackState.IDLE;
-                updatePlayButton(mPlaybackState);
+                videoView.stopPlayback();
+                playbackState = PlaybackState.IDLE;
+                updatePlayButton(playbackState);
                 return true;
             }
         });
 
-        mVideoView.setOnPreparedListener(new OnPreparedListener() {
+        videoView.setOnPreparedListener(new OnPreparedListener() {
 
             @Override
             public void onPrepared(MediaPlayer mp) {
                 Log.d(TAG, "onPrepared is reached");
-                mDuration = mp.getDuration();
-                mEndText.setText(Utils.formatMillis(mDuration));
-                mSeekbar.setMax(mDuration);
+                duration = mp.getDuration();
+                endText.setText(Utils.formatMillis(duration));
+                seekBar.setMax(duration);
                 restartTrickplayTimer();
             }
         });
 
-        mVideoView.setOnCompletionListener(new OnCompletionListener() {
+        videoView.setOnCompletionListener(new OnCompletionListener() {
 
             @Override
             public void onCompletion(MediaPlayer mp) {
                 stopTrickplayTimer();
                 Log.d(TAG, "setOnCompletionListener()");
-                mPlaybackState = PlaybackState.IDLE;
-                updatePlayButton(mPlaybackState);
+                playbackState = PlaybackState.IDLE;
+                updatePlayButton(playbackState);
             }
         });
 
-        mVideoView.setOnTouchListener(new OnTouchListener() {
+        videoView.setOnTouchListener(new OnTouchListener() {
 
             @Override
             public boolean onTouch(View v, MotionEvent event) {
-                if (!mControllersVisible) {
+                if (!controllersVisible) {
                     updateControllersVisibility(true);
                 }
                 startControllersTimer();
@@ -574,14 +574,14 @@ public class LocalPlayerActivity extends AppCompatActivity {
             }
         });
 
-        mSeekbar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
+        seekBar.setOnSeekBarChangeListener(new OnSeekBarChangeListener() {
 
             @Override
             public void onStopTrackingTouch(SeekBar seekBar) {
-                if (mPlaybackState == PlaybackState.PLAYING) {
+                if (playbackState == PlaybackState.PLAYING) {
                     play(seekBar.getProgress());
-                } else if (mPlaybackState != PlaybackState.IDLE) {
-                    mVideoView.seekTo(seekBar.getProgress());
+                } else if (playbackState != PlaybackState.IDLE) {
+                    videoView.seekTo(seekBar.getProgress());
                 }
                 startControllersTimer();
             }
@@ -589,22 +589,22 @@ public class LocalPlayerActivity extends AppCompatActivity {
             @Override
             public void onStartTrackingTouch(SeekBar seekBar) {
                 stopTrickplayTimer();
-                mVideoView.pause();
+                videoView.pause();
                 stopControllersTimer();
             }
 
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress,
                     boolean fromUser) {
-                mStartText.setText(Utils.formatMillis(progress));
+                startText.setText(Utils.formatMillis(progress));
             }
         });
 
-        mPlayPause.setOnClickListener(new OnClickListener() {
+        playPause.setOnClickListener(new OnClickListener() {
 
             @Override
             public void onClick(View v) {
-                if (mLocation == PlaybackLocation.LOCAL) {
+                if (location == PlaybackLocation.LOCAL) {
                     togglePlayback();
                 }
             }
@@ -612,42 +612,42 @@ public class LocalPlayerActivity extends AppCompatActivity {
     }
 
     private void updateSeekbar(int position, int duration) {
-        mSeekbar.setProgress(position);
-        mSeekbar.setMax(duration);
-        mStartText.setText(Utils.formatMillis(position));
-        mEndText.setText(Utils.formatMillis(duration));
+        seekBar.setProgress(position);
+        seekBar.setMax(duration);
+        startText.setText(Utils.formatMillis(position));
+        endText.setText(Utils.formatMillis(duration));
     }
 
     private void updatePlayButton(PlaybackState state) {
         Log.d(TAG, "Controls: PlayBackState: " + state);
-        boolean isConnected = (mCastSession != null)
-                && (mCastSession.isConnected() || mCastSession.isConnecting());
-        mControllers.setVisibility(isConnected ? View.GONE : View.VISIBLE);
-        mPlayCircle.setVisibility(isConnected ? View.GONE : View.VISIBLE);
+        boolean isConnected = (castSession != null)
+                && (castSession.isConnected() || castSession.isConnecting());
+        controllers.setVisibility(isConnected ? View.GONE : View.VISIBLE);
+        playCircle.setVisibility(isConnected ? View.GONE : View.VISIBLE);
         switch (state) {
             case PLAYING:
-                mLoading.setVisibility(View.INVISIBLE);
-                mPlayPause.setVisibility(View.VISIBLE);
-                mPlayPause.setImageDrawable(
+                loading.setVisibility(View.INVISIBLE);
+                playPause.setVisibility(View.VISIBLE);
+                playPause.setImageDrawable(
                         getResources().getDrawable(R.drawable.ic_av_pause_dark));
-                mPlayCircle.setVisibility(isConnected ? View.VISIBLE : View.GONE);
+                playCircle.setVisibility(isConnected ? View.VISIBLE : View.GONE);
                 break;
             case IDLE:
-                mPlayCircle.setVisibility(View.VISIBLE);
-                mControllers.setVisibility(View.GONE);
-                mCoverArt.setVisibility(View.VISIBLE);
-                mVideoView.setVisibility(View.INVISIBLE);
+                playCircle.setVisibility(View.VISIBLE);
+                controllers.setVisibility(View.GONE);
+                coverArt.setVisibility(View.VISIBLE);
+                videoView.setVisibility(View.INVISIBLE);
                 break;
             case PAUSED:
-                mLoading.setVisibility(View.INVISIBLE);
-                mPlayPause.setVisibility(View.VISIBLE);
-                mPlayPause.setImageDrawable(
+                loading.setVisibility(View.INVISIBLE);
+                playPause.setVisibility(View.VISIBLE);
+                playPause.setImageDrawable(
                         getResources().getDrawable(R.drawable.ic_av_play_dark));
-                mPlayCircle.setVisibility(isConnected ? View.VISIBLE : View.GONE);
+                playCircle.setVisibility(isConnected ? View.VISIBLE : View.GONE);
                 break;
             case BUFFERING:
-                mPlayPause.setVisibility(View.INVISIBLE);
-                mLoading.setVisibility(View.VISIBLE);
+                playPause.setVisibility(View.INVISIBLE);
+                loading.setVisibility(View.VISIBLE);
                 break;
             default:
                 break;
@@ -667,7 +667,7 @@ public class LocalPlayerActivity extends AppCompatActivity {
                 getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LOW_PROFILE);
             }
             updateMetadata(false);
-            mContainer.setBackgroundColor(getResources().getColor(R.color.black));
+            container.setBackgroundColor(getResources().getColor(R.color.black));
 
         } else {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN,
@@ -678,39 +678,39 @@ public class LocalPlayerActivity extends AppCompatActivity {
                 getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
             }
             updateMetadata(true);
-            mContainer.setBackgroundColor(getResources().getColor(R.color.white));
+            container.setBackgroundColor(getResources().getColor(R.color.white));
         }
     }
 
     private void updateMetadata(boolean visible) {
         Point displaySize;
         if (!visible) {
-            mDescriptionView.setVisibility(View.GONE);
-            mTitleView.setVisibility(View.GONE);
-            mAuthorView.setVisibility(View.GONE);
+            descriptionView.setVisibility(View.GONE);
+            titleView.setVisibility(View.GONE);
+            authorView.setVisibility(View.GONE);
             displaySize = Utils.getDisplaySize(this);
             RelativeLayout.LayoutParams lp = new
                     RelativeLayout.LayoutParams(displaySize.x,
                     displaySize.y + getSupportActionBar().getHeight());
             lp.addRule(RelativeLayout.CENTER_IN_PARENT);
-            mVideoView.setLayoutParams(lp);
-            mVideoView.invalidate();
+            videoView.setLayoutParams(lp);
+            videoView.invalidate();
         } else {
-            MediaMetadata mm = mSelectedMedia.getMetadata();
-            mDescriptionView.setText(mSelectedMedia.getCustomData().optString(
+            MediaMetadata mm = selectedMedia.getMetadata();
+            descriptionView.setText(selectedMedia.getCustomData().optString(
                     VideoProvider.KEY_DESCRIPTION));
-            mTitleView.setText(mm.getString(MediaMetadata.KEY_TITLE));
-            mAuthorView.setText(mm.getString(MediaMetadata.KEY_SUBTITLE));
-            mDescriptionView.setVisibility(View.VISIBLE);
-            mTitleView.setVisibility(View.VISIBLE);
-            mAuthorView.setVisibility(View.VISIBLE);
+            titleView.setText(mm.getString(MediaMetadata.KEY_TITLE));
+            authorView.setText(mm.getString(MediaMetadata.KEY_SUBTITLE));
+            descriptionView.setVisibility(View.VISIBLE);
+            titleView.setVisibility(View.VISIBLE);
+            authorView.setVisibility(View.VISIBLE);
             displaySize = Utils.getDisplaySize(this);
             RelativeLayout.LayoutParams lp = new
                     RelativeLayout.LayoutParams(displaySize.x,
-                    (int) (displaySize.x * mAspectRatio));
+                    (int) (displaySize.x * aspectRatio));
             lp.addRule(RelativeLayout.BELOW, R.id.toolbar);
-            mVideoView.setLayoutParams(lp);
-            mVideoView.invalidate();
+            videoView.setLayoutParams(lp);
+            videoView.invalidate();
         }
     }
 
@@ -720,14 +720,14 @@ public class LocalPlayerActivity extends AppCompatActivity {
         getMenuInflater().inflate(R.menu.player, menu);
         CastButtonFactory.setUpMediaRouteButton(getApplicationContext(), menu,
                 R.id.media_route_menu_item);
-        mQueueMenuItem = menu.findItem(R.id.action_show_queue);
+        queueMenuItem = menu.findItem(R.id.action_show_queue);
         return true;
     }
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         menu.findItem(R.id.action_show_queue).setVisible(
-                (mCastSession != null) && mCastSession.isConnected());
+                (castSession != null) && castSession.isConnected());
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -748,29 +748,29 @@ public class LocalPlayerActivity extends AppCompatActivity {
 
     private void setupActionBar() {
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        toolbar.setTitle(mSelectedMedia.getMetadata().getString(MediaMetadata.KEY_TITLE));
+        toolbar.setTitle(selectedMedia.getMetadata().getString(MediaMetadata.KEY_TITLE));
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
 
     private void loadViews() {
-        mVideoView = (VideoView) findViewById(R.id.videoView1);
-        mTitleView = (TextView) findViewById(R.id.titleTextView);
-        mDescriptionView = (TextView) findViewById(R.id.descriptionTextView);
-        mDescriptionView.setMovementMethod(new ScrollingMovementMethod());
-        mAuthorView = (TextView) findViewById(R.id.authorTextView);
-        mStartText = (TextView) findViewById(R.id.startText);
-        mStartText.setText(Utils.formatMillis(0));
-        mEndText = (TextView) findViewById(R.id.endText);
-        mSeekbar = (SeekBar) findViewById(R.id.seekBar1);
-        mPlayPause = (ImageView) findViewById(R.id.playPauseImageView);
-        mLoading = (ProgressBar) findViewById(R.id.progressBar1);
-        mControllers = findViewById(R.id.controllers);
-        mContainer = findViewById(R.id.container);
-        mCoverArt = (ImageView) findViewById(R.id.coverArtView);
-        ViewCompat.setTransitionName(mCoverArt, getString(R.string.transition_image));
-        mPlayCircle = (ImageButton) findViewById(R.id.play_circle);
-        mPlayCircle.setOnClickListener(new OnClickListener() {
+        videoView = (VideoView) findViewById(R.id.videoView1);
+        titleView = (TextView) findViewById(R.id.titleTextView);
+        descriptionView = (TextView) findViewById(R.id.descriptionTextView);
+        descriptionView.setMovementMethod(new ScrollingMovementMethod());
+        authorView = (TextView) findViewById(R.id.authorTextView);
+        startText = (TextView) findViewById(R.id.startText);
+        startText.setText(Utils.formatMillis(0));
+        endText = (TextView) findViewById(R.id.endText);
+        seekBar = (SeekBar) findViewById(R.id.seekBar1);
+        playPause = (ImageView) findViewById(R.id.playPauseImageView);
+        loading = (ProgressBar) findViewById(R.id.progressBar1);
+        controllers = findViewById(R.id.controllers);
+        container = findViewById(R.id.container);
+        coverArt = (ImageView) findViewById(R.id.coverArtView);
+        ViewCompat.setTransitionName(coverArt, getString(R.string.transition_image));
+        playCircle = (ImageButton) findViewById(R.id.play_circle);
+        playCircle.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 togglePlayback();

--- a/src/com/google/sample/cast/refplayer/queue/QueueDataProvider.java
+++ b/src/com/google/sample/cast/refplayer/queue/QueueDataProvider.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * A singleton to manage the queue. Upon instantiation, it syncs up its own copy of the queue with
  * the one that the VideoCastManager holds. After that point, it maintains an up-to-date version of
- * the queue. UI elements get their data from this class. A boolean field, {@code mDetachedQueue}
+ * the queue. UI elements get their data from this class. A boolean field, {@code detachedQueue}
  * is used to manage whether this changes to the queue coming from the cast framework should be
  * reflected here or not; when in "detached" mode, it means that its own copy of the queue is not
  * kept up to date with the one that the cast framework has. This is needed to preserve the queue
@@ -43,29 +43,29 @@ public class QueueDataProvider {
 
     private static final String TAG = "QueueDataProvider";
     public static final int INVALID = -1;
-    private final Context mAppContext;
-    private final List<MediaQueueItem> mQueue = new CopyOnWriteArrayList<>();
-    private static QueueDataProvider mInstance;
+    private final Context appContext;
+    private final List<MediaQueueItem> queue = new CopyOnWriteArrayList<>();
+    private static QueueDataProvider instance;
     // Locks modification to the remove queue.
-    private final Object mLock = new Object();
-    private final SessionManagerListener<CastSession> mSessionManagerListener =
+    private final Object lock = new Object();
+    private final SessionManagerListener<CastSession> sessionManagerListener =
             new MySessionManagerListener();
-    private final RemoteMediaClient.Listener mRemoteMediaClientListener =
+    private final RemoteMediaClient.Listener remoteMediaClientListener =
             new MyRemoteMediaClientListener();
-    private int mRepeatMode;
-    private boolean mShuffle;
-    private MediaQueueItem mCurrentIem;
-    private MediaQueueItem mUpcomingItem;
-    private OnQueueDataChangedListener mListener;
-    private boolean mDetachedQueue = true;
+    private int repeatMode;
+    private boolean shuffle;
+    private MediaQueueItem currentIem;
+    private MediaQueueItem upcomingItem;
+    private OnQueueDataChangedListener listener;
+    private boolean detachedQueue = true;
 
     private QueueDataProvider(Context context) {
-        mAppContext = context.getApplicationContext();
-        mRepeatMode = MediaStatus.REPEAT_MODE_REPEAT_OFF;
-        mShuffle = false;
-        mCurrentIem = null;
-        CastContext.getSharedInstance(mAppContext).getSessionManager().addSessionManagerListener(
-                mSessionManagerListener, CastSession.class);
+        appContext = context.getApplicationContext();
+        repeatMode = MediaStatus.REPEAT_MODE_REPEAT_OFF;
+        shuffle = false;
+        currentIem = null;
+        CastContext.getSharedInstance(appContext).getSessionManager().addSessionManagerListener(
+                sessionManagerListener, CastSession.class);
         syncWithRemoteQueue();
     }
 
@@ -80,7 +80,7 @@ public class QueueDataProvider {
         int position = getPositionByItemId(upcomingItem.getItemId());
         int[] itemIds = new int[getCount() - position];
         for (int i = 0; i < itemIds.length; i++) {
-            itemIds[i] = mQueue.get(i + position).getItemId();
+            itemIds[i] = queue.get(i + position).getItemId();
         }
         remoteMediaClient.queueRemoveItems(itemIds, null);
     }
@@ -94,15 +94,15 @@ public class QueueDataProvider {
     }
 
     public boolean isQueueDetached() {
-        return mDetachedQueue;
+        return detachedQueue;
     }
 
     public int getPositionByItemId(int itemId) {
-        if (mQueue.isEmpty()) {
+        if (queue.isEmpty()) {
             return INVALID;
         }
-        for (int i = 0; i < mQueue.size(); i++) {
-            if (mQueue.get(i).getItemId() == itemId) {
+        for (int i = 0; i < queue.size(); i++) {
+            if (queue.get(i).getItemId() == itemId) {
                 return i;
             }
         }
@@ -110,37 +110,37 @@ public class QueueDataProvider {
     }
 
     public static synchronized QueueDataProvider getInstance(Context context) {
-        if (mInstance == null) {
-            mInstance = new QueueDataProvider(context);
+        if (instance == null) {
+            instance = new QueueDataProvider(context);
         }
-        return mInstance;
+        return instance;
     }
 
     public void removeFromQueue(int position) {
-        synchronized (mLock) {
+        synchronized (lock) {
             RemoteMediaClient remoteMediaClient = getRemoteMediaClient();
             if (remoteMediaClient == null) {
                 return;
             }
-            remoteMediaClient.queueRemoveItem(mQueue.get(position).getItemId(), null);
+            remoteMediaClient.queueRemoveItem(queue.get(position).getItemId(), null);
         }
     }
 
     public void removeAll() {
-        synchronized (mLock) {
-            if (mQueue.isEmpty()) {
+        synchronized (lock) {
+            if (queue.isEmpty()) {
                 return;
             }
             RemoteMediaClient remoteMediaClient = getRemoteMediaClient();
             if (remoteMediaClient == null) {
                 return;
             }
-            int[] itemIds = new int[mQueue.size()];
-            for (int i = 0; i < mQueue.size(); i++) {
-                itemIds[i] = mQueue.get(i).getItemId();
+            int[] itemIds = new int[queue.size()];
+            for (int i = 0; i < queue.size(); i++) {
+                itemIds[i] = queue.get(i).getItemId();
             }
             remoteMediaClient.queueRemoveItems(itemIds, null);
-            mQueue.clear();
+            queue.clear();
         }
     }
 
@@ -152,54 +152,54 @@ public class QueueDataProvider {
         if (remoteMediaClient == null) {
             return;
         }
-        int itemId = mQueue.get(fromPosition).getItemId();
+        int itemId = queue.get(fromPosition).getItemId();
 
         remoteMediaClient.queueMoveItemToNewIndex(itemId, toPosition, null);
-        final MediaQueueItem item = mQueue.remove(fromPosition);
-        mQueue.add(toPosition, item);
+        final MediaQueueItem item = queue.remove(fromPosition);
+        queue.add(toPosition, item);
     }
 
     public int getCount() {
-        return mQueue.size();
+        return queue.size();
     }
 
     public MediaQueueItem getItem(int position) {
-        return mQueue.get(position);
+        return queue.get(position);
     }
 
     public void clearQueue() {
-        mQueue.clear();
-        mDetachedQueue = true;
-        mCurrentIem = null;
+        queue.clear();
+        detachedQueue = true;
+        currentIem = null;
     }
 
     public int getRepeatMode() {
-        return mRepeatMode;
+        return repeatMode;
     }
 
     public boolean isShuffleOn() {
-        return mShuffle;
+        return shuffle;
     }
 
     public MediaQueueItem getCurrentItem() {
-        return mCurrentIem;
+        return currentIem;
     }
 
     public int getCurrentItemId() {
-        return mCurrentIem.getItemId();
+        return currentIem.getItemId();
     }
 
     public MediaQueueItem getUpcomingItem() {
-        Log.d(TAG, "[upcoming] getUpcomingItem() returning " + mUpcomingItem);
-        return mUpcomingItem;
+        Log.d(TAG, "[upcoming] getUpcomingItem() returning " + upcomingItem);
+        return upcomingItem;
     }
 
     public void setOnQueueDataChangedListener(OnQueueDataChangedListener listener) {
-        mListener = listener;
+        this.listener = listener;
     }
 
     public List<MediaQueueItem> getItems() {
-        return mQueue;
+        return queue;
     }
 
     /**
@@ -213,17 +213,17 @@ public class QueueDataProvider {
     private void syncWithRemoteQueue() {
         RemoteMediaClient remoteMediaClient = getRemoteMediaClient();
         if (remoteMediaClient != null) {
-            remoteMediaClient.addListener(mRemoteMediaClientListener);
+            remoteMediaClient.addListener(remoteMediaClientListener);
             MediaStatus mediaStatus = remoteMediaClient.getMediaStatus();
             if (mediaStatus != null) {
                 List<MediaQueueItem> items = mediaStatus.getQueueItems();
                 if (items != null && !items.isEmpty()) {
-                    mQueue.clear();
-                    mQueue.addAll(items);
-                    mRepeatMode = mediaStatus.getQueueRepeatMode();
-                    mCurrentIem = mediaStatus.getQueueItemById(mediaStatus.getCurrentItemId());
-                    mDetachedQueue = false;
-                    mUpcomingItem = mediaStatus.getQueueItemById(mediaStatus.getPreloadedItemId());
+                    queue.clear();
+                    queue.addAll(items);
+                    repeatMode = mediaStatus.getQueueRepeatMode();
+                    currentIem = mediaStatus.getQueueItemById(mediaStatus.getCurrentItemId());
+                    detachedQueue = false;
+                    upcomingItem = mediaStatus.getQueueItemById(mediaStatus.getPreloadedItemId());
                 }
             }
         }
@@ -244,8 +244,8 @@ public class QueueDataProvider {
         @Override
         public void onSessionEnded(CastSession session, int error) {
             clearQueue();
-            if (mListener != null) {
-                mListener.onQueueDataChanged();
+            if (listener != null) {
+                listener.onQueueDataChanged();
             }
         }
 
@@ -286,18 +286,18 @@ public class QueueDataProvider {
             if (mediaStatus == null) {
                 return;
             }
-            mUpcomingItem = mediaStatus.getQueueItemById(mediaStatus.getPreloadedItemId());
-            Log.d(TAG, "onRemoteMediaPreloadStatusUpdated() with item=" + mUpcomingItem);
-            if (mListener != null) {
-                mListener.onQueueDataChanged();
+            upcomingItem = mediaStatus.getQueueItemById(mediaStatus.getPreloadedItemId());
+            Log.d(TAG, "onRemoteMediaPreloadStatusUpdated() with item=" + upcomingItem);
+            if (listener != null) {
+                listener.onQueueDataChanged();
             }
         }
 
         @Override
         public void onQueueStatusUpdated() {
             updateMediaQueue();
-            if (mListener != null) {
-                mListener.onQueueDataChanged();
+            if (listener != null) {
+                listener.onQueueDataChanged();
             }
             Log.d(TAG, "Queue was updated");
         }
@@ -305,8 +305,8 @@ public class QueueDataProvider {
         @Override
         public void onStatusUpdated() {
             updateMediaQueue();
-            if (mListener != null) {
-                mListener.onQueueDataChanged();
+            if (listener != null) {
+                listener.onQueueDataChanged();
             }
         }
 
@@ -326,27 +326,27 @@ public class QueueDataProvider {
                 mediaStatus = remoteMediaClient.getMediaStatus();
                 if (mediaStatus != null) {
                     queueItems = mediaStatus.getQueueItems();
-                    mRepeatMode = mediaStatus.getQueueRepeatMode();
-                    mCurrentIem = mediaStatus.getQueueItemById(mediaStatus.getCurrentItemId());
+                    repeatMode = mediaStatus.getQueueRepeatMode();
+                    currentIem = mediaStatus.getQueueItemById(mediaStatus.getCurrentItemId());
                 }
             }
-            mQueue.clear();
+            queue.clear();
             if (queueItems == null) {
                 Log.d(TAG, "Queue is cleared");
             } else {
                 Log.d(TAG, "Queue is updated with a list of size: " + queueItems.size());
                 if (queueItems.size() > 0) {
-                    mQueue.addAll(queueItems);
-                    mDetachedQueue = false;
+                    queue.addAll(queueItems);
+                    detachedQueue = false;
                 } else {
-                    mDetachedQueue = true;
+                    detachedQueue = true;
                 }
             }
         }
     }
 
     private RemoteMediaClient getRemoteMediaClient() {
-        CastSession castSession = CastContext.getSharedInstance(mAppContext).getSessionManager()
+        CastSession castSession = CastContext.getSharedInstance(appContext).getSessionManager()
                 .getCurrentCastSession();
         if (castSession == null || !castSession.isConnected()) {
             Log.w(TAG, "Trying to get a RemoteMediaClient when no CastSession is started.");

--- a/src/com/google/sample/cast/refplayer/queue/ui/QueueItemTouchHelperCallback.java
+++ b/src/com/google/sample/cast/refplayer/queue/ui/QueueItemTouchHelperCallback.java
@@ -25,10 +25,10 @@ import android.support.v7.widget.helper.ItemTouchHelper;
  */
 public class QueueItemTouchHelperCallback extends ItemTouchHelper.Callback {
 
-    private final ItemTouchHelperAdapter mAdapter;
+    private final ItemTouchHelperAdapter adapter;
 
     public QueueItemTouchHelperCallback(ItemTouchHelperAdapter adapter) {
-        mAdapter = adapter;
+        this.adapter = adapter;
     }
 
     @Override
@@ -55,13 +55,13 @@ public class QueueItemTouchHelperCallback extends ItemTouchHelper.Callback {
             return false;
         }
 
-        mAdapter.onItemMove(source.getAdapterPosition(), target.getAdapterPosition());
+        adapter.onItemMove(source.getAdapterPosition(), target.getAdapterPosition());
         return true;
     }
 
     @Override
     public void onSwiped(RecyclerView.ViewHolder viewHolder, int i) {
-        mAdapter.onItemDismiss(viewHolder.getAdapterPosition());
+        adapter.onItemDismiss(viewHolder.getAdapterPosition());
     }
 
     @Override
@@ -71,7 +71,7 @@ public class QueueItemTouchHelperCallback extends ItemTouchHelper.Callback {
             if (viewHolder instanceof QueueListAdapter.QueueItemViewHolder) {
                 QueueListAdapter.QueueItemViewHolder queueHolder
                         = (QueueListAdapter.QueueItemViewHolder) viewHolder;
-                ViewCompat.setTranslationX(queueHolder.mContainer, dX);
+                ViewCompat.setTranslationX(queueHolder.container, dX);
             }
         } else {
             super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);

--- a/src/com/google/sample/cast/refplayer/queue/ui/QueueListAdapter.java
+++ b/src/com/google/sample/cast/refplayer/queue/ui/QueueListAdapter.java
@@ -53,28 +53,28 @@ public class QueueListAdapter extends RecyclerView.Adapter<QueueListAdapter.Queu
 
     private static final String TAG = "QueueListAdapter";
     private static final int IMAGE_THUMBNAIL_WIDTH = 64;
-    private final QueueDataProvider mProvider;
+    private final QueueDataProvider provider;
     private static final int PLAY_RESOURCE = R.drawable.ic_play_arrow_grey600_48dp;
     private static final int PAUSE_RESOURCE = R.drawable.ic_pause_grey600_48dp;
     private static final int DRAG_HANDLER_DARK_RESOURCE = R.drawable.ic_drag_updown_grey_24dp;
     private static final int DRAG_HANDLER_LIGHT_RESOURCE = R.drawable.ic_drag_updown_white_24dp;
-    private final Context mAppContext;
-    private final OnStartDragListener mDragStartListener;
-    private View.OnClickListener mItemViewOnClickListener;
+    private final Context appContext;
+    private final OnStartDragListener dragStartListener;
+    private View.OnClickListener itemViewOnClickListener;
     private static final float ASPECT_RATIO = 1f;
-    private EventListener mEventListener;
+    private EventListener eventListener;
 
     public QueueListAdapter(Context context, OnStartDragListener dragStartListener) {
-        mAppContext = context.getApplicationContext();
-        mDragStartListener = dragStartListener;
-        mProvider = QueueDataProvider.getInstance(context);
-        mProvider.setOnQueueDataChangedListener(new QueueDataProvider.OnQueueDataChangedListener() {
+        appContext = context.getApplicationContext();
+        this.dragStartListener = dragStartListener;
+        provider = QueueDataProvider.getInstance(context);
+        provider.setOnQueueDataChangedListener(new QueueDataProvider.OnQueueDataChangedListener() {
             @Override
             public void onQueueDataChanged() {
                 notifyDataSetChanged();
             }
         });
-        mItemViewOnClickListener = new View.OnClickListener() {
+        itemViewOnClickListener = new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 if (view.getTag(R.string.queue_tag_item) != null) {
@@ -89,18 +89,18 @@ public class QueueListAdapter extends RecyclerView.Adapter<QueueListAdapter.Queu
 
     @Override
     public long getItemId(int position) {
-        return (long) mProvider.getItem(position).getItemId();
+        return (long) provider.getItem(position).getItemId();
     }
 
     private void onItemViewClick(View view) {
-        if (mEventListener != null) {
-            mEventListener.onItemViewClicked(view);
+        if (eventListener != null) {
+            eventListener.onItemViewClicked(view);
         }
     }
 
     @Override
     public void onItemDismiss(int position) {
-        mProvider.removeFromQueue(position);
+        provider.removeFromQueue(position);
     }
 
     @Override
@@ -108,7 +108,7 @@ public class QueueListAdapter extends RecyclerView.Adapter<QueueListAdapter.Queu
         if (fromPosition == toPosition) {
             return false;
         }
-        mProvider.moveItem(fromPosition, toPosition);
+        provider.moveItem(fromPosition, toPosition);
         notifyItemMoved(fromPosition, toPosition);
         return true;
     }
@@ -123,53 +123,53 @@ public class QueueListAdapter extends RecyclerView.Adapter<QueueListAdapter.Queu
     @Override
     public void onBindViewHolder(final QueueItemViewHolder holder, int position) {
         Log.d(TAG, "[upcoming] onBindViewHolder() for position: " + position);
-        final MediaQueueItem item = mProvider.getItem(position);
-        holder.mContainer.setTag(R.string.queue_tag_item, item);
-        holder.mPlayPause.setTag(R.string.queue_tag_item, item);
-        holder.mPlayUpcoming.setTag(R.string.queue_tag_item, item);
-        holder.mStopUpcoming.setTag(R.string.queue_tag_item, item);
+        final MediaQueueItem item = provider.getItem(position);
+        holder.container.setTag(R.string.queue_tag_item, item);
+        holder.playPause.setTag(R.string.queue_tag_item, item);
+        holder.playUpcoming.setTag(R.string.queue_tag_item, item);
+        holder.stopUpcoming.setTag(R.string.queue_tag_item, item);
 
         // Set listeners
-        holder.mContainer.setOnClickListener(mItemViewOnClickListener);
-        holder.mPlayPause.setOnClickListener(mItemViewOnClickListener);
-        holder.mPlayUpcoming.setOnClickListener(mItemViewOnClickListener);
-        holder.mStopUpcoming.setOnClickListener(mItemViewOnClickListener);
+        holder.container.setOnClickListener(itemViewOnClickListener);
+        holder.playPause.setOnClickListener(itemViewOnClickListener);
+        holder.playUpcoming.setOnClickListener(itemViewOnClickListener);
+        holder.stopUpcoming.setOnClickListener(itemViewOnClickListener);
 
         MediaInfo info = item.getMedia();
         MediaMetadata metaData = info.getMetadata();
-        holder.mTitleView.setText(metaData.getString(MediaMetadata.KEY_TITLE));
-        holder.mDescriptionView.setText(metaData.getString(MediaMetadata.KEY_SUBTITLE));
+        holder.titleView.setText(metaData.getString(MediaMetadata.KEY_TITLE));
+        holder.descriptionView.setText(metaData.getString(MediaMetadata.KEY_SUBTITLE));
         AQuery aq = new AQuery(holder.itemView);
         if (!metaData.getImages().isEmpty()) {
-            aq.id(holder.mImageView).width(IMAGE_THUMBNAIL_WIDTH)
+            aq.id(holder.imageView).width(IMAGE_THUMBNAIL_WIDTH)
                     .image(metaData.getImages().get(0).getUrl().toString(), true, true, 0,
                             R.drawable.default_video, null, 0, ASPECT_RATIO);
         }
 
-        holder.mDragHandle.setOnTouchListener(new View.OnTouchListener() {
+        holder.dragHandle.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View view, MotionEvent event) {
                 if (MotionEventCompat.getActionMasked(event) == MotionEvent.ACTION_DOWN) {
-                    mDragStartListener.onStartDrag(holder);
+                    dragStartListener.onStartDrag(holder);
                 }
                 return false;
             }
         });
 
-        if (item == mProvider.getCurrentItem()) {
+        if (item == provider.getCurrentItem()) {
             holder.updateControlsStatus(QueueItemViewHolder.CURRENT);
-            updatePlayPauseButtonImageResource(holder.mPlayPause);
-        } else if (item == mProvider.getUpcomingItem()) {
+            updatePlayPauseButtonImageResource(holder.playPause);
+        } else if (item == provider.getUpcomingItem()) {
             holder.updateControlsStatus(QueueItemViewHolder.UPCOMING);
         } else {
             holder.updateControlsStatus(QueueItemViewHolder.NONE);
-            holder.mPlayPause.setVisibility(View.GONE);
+            holder.playPause.setVisibility(View.GONE);
         }
 
     }
 
     private void updatePlayPauseButtonImageResource(ImageButton button) {
-        CastSession castSession = CastContext.getSharedInstance(mAppContext)
+        CastSession castSession = CastContext.getSharedInstance(appContext)
                 .getSessionManager().getCurrentCastSession();
         RemoteMediaClient remoteMediaClient =
                 (castSession == null) ? null : castSession.getRemoteMediaClient();
@@ -192,23 +192,23 @@ public class QueueListAdapter extends RecyclerView.Adapter<QueueListAdapter.Queu
 
     @Override
     public int getItemCount() {
-        return QueueDataProvider.getInstance(mAppContext).getCount();
+        return QueueDataProvider.getInstance(appContext).getCount();
     }
 
     /* package */ static class QueueItemViewHolder extends RecyclerView.ViewHolder implements
             ItemTouchHelperViewHolder {
 
-        private Context mContext;
-        private final ImageButton mPlayPause;
-        private View mControls;
-        private View mUpcomingControls;
-        private ImageButton mPlayUpcoming;
-        private ImageButton mStopUpcoming;
-        public ImageView mImageView;
-        public ViewGroup mContainer;
-        public ImageView mDragHandle;
-        public TextView mTitleView;
-        public TextView mDescriptionView;
+        private Context context;
+        private final ImageButton playPause;
+        private View controls;
+        private View upcomingControls;
+        private ImageButton playUpcoming;
+        private ImageButton stopUpcoming;
+        public ImageView imageView;
+        public ViewGroup container;
+        public ImageView dragHandle;
+        public TextView titleView;
+        public TextView descriptionView;
 
         @Override
         public void onItemSelected() {
@@ -232,58 +232,58 @@ public class QueueListAdapter extends RecyclerView.Adapter<QueueListAdapter.Queu
 
         public QueueItemViewHolder(View itemView) {
             super(itemView);
-            mContext = itemView.getContext();
-            mContainer = (ViewGroup) itemView.findViewById(R.id.container);
-            mDragHandle = (ImageView) itemView.findViewById(R.id.drag_handle);
-            mTitleView = (TextView) itemView.findViewById(R.id.textView1);
-            mDescriptionView = (TextView) itemView.findViewById(R.id.textView2);
-            mImageView = (ImageView) itemView.findViewById(R.id.imageView1);
-            mPlayPause = (ImageButton) itemView.findViewById(R.id.play_pause);
-            mControls = itemView.findViewById(R.id.controls);
-            mUpcomingControls = itemView.findViewById(R.id.controls_upcoming);
-            mPlayUpcoming = (ImageButton) itemView.findViewById(R.id.play_upcoming);
-            mStopUpcoming = (ImageButton) itemView.findViewById(R.id.stop_upcoming);
+            context = itemView.getContext();
+            container = (ViewGroup) itemView.findViewById(R.id.container);
+            dragHandle = (ImageView) itemView.findViewById(R.id.drag_handle);
+            titleView = (TextView) itemView.findViewById(R.id.textView1);
+            descriptionView = (TextView) itemView.findViewById(R.id.textView2);
+            imageView = (ImageView) itemView.findViewById(R.id.imageView1);
+            playPause = (ImageButton) itemView.findViewById(R.id.play_pause);
+            controls = itemView.findViewById(R.id.controls);
+            upcomingControls = itemView.findViewById(R.id.controls_upcoming);
+            playUpcoming = (ImageButton) itemView.findViewById(R.id.play_upcoming);
+            stopUpcoming = (ImageButton) itemView.findViewById(R.id.stop_upcoming);
         }
 
         private void updateControlsStatus(@ControlStatus int status) {
             int bgResId = R.drawable.bg_item_normal_state;
-            mTitleView.setTextAppearance(mContext, R.style.Base_TextAppearance_AppCompat_Subhead);
-            mDescriptionView.setTextAppearance(mContext,
+            titleView.setTextAppearance(context, R.style.Base_TextAppearance_AppCompat_Subhead);
+            descriptionView.setTextAppearance(context,
                     R.style.Base_TextAppearance_AppCompat_Caption);
             switch (status) {
                 case CURRENT:
                     bgResId = R.drawable.bg_item_normal_state;
-                    mControls.setVisibility(View.VISIBLE);
-                    mPlayPause.setVisibility(View.VISIBLE);
-                    mUpcomingControls.setVisibility(View.GONE);
-                    mDragHandle.setImageResource(DRAG_HANDLER_DARK_RESOURCE);
+                    controls.setVisibility(View.VISIBLE);
+                    playPause.setVisibility(View.VISIBLE);
+                    upcomingControls.setVisibility(View.GONE);
+                    dragHandle.setImageResource(DRAG_HANDLER_DARK_RESOURCE);
                     break;
                 case UPCOMING:
-                    mControls.setVisibility(View.VISIBLE);
-                    mPlayPause.setVisibility(View.GONE);
-                    mUpcomingControls.setVisibility(View.VISIBLE);
-                    mDragHandle.setImageResource(DRAG_HANDLER_LIGHT_RESOURCE);
+                    controls.setVisibility(View.VISIBLE);
+                    playPause.setVisibility(View.GONE);
+                    upcomingControls.setVisibility(View.VISIBLE);
+                    dragHandle.setImageResource(DRAG_HANDLER_LIGHT_RESOURCE);
                     bgResId = R.drawable.bg_item_upcoming_state;
-                    mTitleView.setTextAppearance(mContext,
+                    titleView.setTextAppearance(context,
                             R.style.TextAppearance_AppCompat_Small_Inverse);
-                    mTitleView.setTextAppearance(mTitleView.getContext(),
+                    titleView.setTextAppearance(titleView.getContext(),
                             R.style.Base_TextAppearance_AppCompat_Subhead_Inverse);
-                    mDescriptionView.setTextAppearance(mContext,
+                    descriptionView.setTextAppearance(context,
                             R.style.Base_TextAppearance_AppCompat_Caption);
                     break;
                 default:
-                    mControls.setVisibility(View.GONE);
-                    mPlayPause.setVisibility(View.GONE);
-                    mUpcomingControls.setVisibility(View.GONE);
-                    mDragHandle.setImageResource(DRAG_HANDLER_DARK_RESOURCE);
+                    controls.setVisibility(View.GONE);
+                    playPause.setVisibility(View.GONE);
+                    upcomingControls.setVisibility(View.GONE);
+                    dragHandle.setImageResource(DRAG_HANDLER_DARK_RESOURCE);
                     break;
             }
-            mContainer.setBackgroundResource(bgResId);
+            container.setBackgroundResource(bgResId);
         }
     }
 
     public void setEventListener(EventListener eventListener) {
-        mEventListener = eventListener;
+        this.eventListener = eventListener;
     }
 
     /**

--- a/src/com/google/sample/cast/refplayer/queue/ui/QueueListViewActivity.java
+++ b/src/com/google/sample/cast/refplayer/queue/ui/QueueListViewActivity.java
@@ -48,38 +48,38 @@ public class QueueListViewActivity extends AppCompatActivity {
     private static final String FRAGMENT_LIST_VIEW = "list view";
     private static final String TAG = "QueueListViewActivity";
 
-    private final RemoteMediaClient.Listener mRemoteMediaClientListener =
+    private final RemoteMediaClient.Listener remoteMediaClientListener =
             new MyRemoteMediaClientListener();
-    private final SessionManagerListener<CastSession> mSessionManagerListener =
+    private final SessionManagerListener<CastSession> sessionManagerListener =
             new MySessionManagerListener();
-    private CastContext mCastContext;
-    private RemoteMediaClient mRemoteMediaClient;
-    private View mEmptyView;
+    private CastContext castContext;
+    private RemoteMediaClient remoteMediaClient;
+    private View emptyView;
 
     private class MySessionManagerListener implements SessionManagerListener<CastSession> {
 
         @Override
         public void onSessionEnded(CastSession session, int error) {
-            if (mRemoteMediaClient != null) {
-                mRemoteMediaClient.removeListener(mRemoteMediaClientListener);
+            if (remoteMediaClient != null) {
+                remoteMediaClient.removeListener(remoteMediaClientListener);
             }
-            mRemoteMediaClient = null;
-            mEmptyView.setVisibility(View.VISIBLE);
+            remoteMediaClient = null;
+            emptyView.setVisibility(View.VISIBLE);
         }
 
         @Override
         public void onSessionResumed(CastSession session, boolean wasSuspended) {
-            mRemoteMediaClient = getRemoteMediaClient();
-            if (mRemoteMediaClient != null) {
-                mRemoteMediaClient.addListener(mRemoteMediaClientListener);
+            remoteMediaClient = getRemoteMediaClient();
+            if (remoteMediaClient != null) {
+                remoteMediaClient.addListener(remoteMediaClientListener);
             }
         }
 
         @Override
         public void onSessionStarted(CastSession session, String sessionId) {
-            mRemoteMediaClient = getRemoteMediaClient();
-            if (mRemoteMediaClient != null) {
-                mRemoteMediaClient.addListener(mRemoteMediaClientListener);
+            remoteMediaClient = getRemoteMediaClient();
+            if (remoteMediaClient != null) {
+                remoteMediaClient.addListener(remoteMediaClientListener);
             }
         }
 
@@ -105,10 +105,10 @@ public class QueueListViewActivity extends AppCompatActivity {
 
         @Override
         public void onSessionSuspended(CastSession session, int reason) {
-            if (mRemoteMediaClient != null) {
-                mRemoteMediaClient.removeListener(mRemoteMediaClientListener);
+            if (remoteMediaClient != null) {
+                remoteMediaClient.removeListener(remoteMediaClientListener);
             }
-            mRemoteMediaClient = null;
+            remoteMediaClient = null;
         }
     }
 
@@ -137,13 +137,13 @@ public class QueueListViewActivity extends AppCompatActivity {
         }
 
         private void updateMediaQueue() {
-            MediaStatus mediaStatus = mRemoteMediaClient.getMediaStatus();
+            MediaStatus mediaStatus = remoteMediaClient.getMediaStatus();
             List<MediaQueueItem> queueItems =
                     (mediaStatus == null) ? null : mediaStatus.getQueueItems();
             if (queueItems == null || queueItems.isEmpty()) {
-                mEmptyView.setVisibility(View.VISIBLE);
+                emptyView.setVisibility(View.VISIBLE);
             } else {
-                mEmptyView.setVisibility(View.GONE);
+                emptyView.setVisibility(View.GONE);
             }
         }
     }
@@ -160,9 +160,9 @@ public class QueueListViewActivity extends AppCompatActivity {
                     .commit();
         }
         setupActionBar();
-        mEmptyView = findViewById(R.id.empty);
-        mCastContext = CastContext.getSharedInstance(this);
-        mCastContext.registerLifecycleCallbacksBeforeIceCreamSandwich(this, savedInstanceState);
+        emptyView = findViewById(R.id.empty);
+        castContext = CastContext.getSharedInstance(this);
+        castContext.registerLifecycleCallbacksBeforeIceCreamSandwich(this, savedInstanceState);
     }
 
 
@@ -175,11 +175,11 @@ public class QueueListViewActivity extends AppCompatActivity {
 
     @Override
     protected void onPause() {
-        if (mRemoteMediaClient != null) {
-            mRemoteMediaClient.removeListener(mRemoteMediaClientListener);
+        if (remoteMediaClient != null) {
+            remoteMediaClient.removeListener(remoteMediaClientListener);
         }
-        mCastContext.getSessionManager().removeSessionManagerListener(
-                mSessionManagerListener, CastSession.class);
+        castContext.getSessionManager().removeSessionManagerListener(
+                sessionManagerListener, CastSession.class);
         super.onPause();
     }
 
@@ -210,31 +210,31 @@ public class QueueListViewActivity extends AppCompatActivity {
 
     @Override
     public boolean dispatchKeyEvent(@NonNull KeyEvent event) {
-        return mCastContext.onDispatchVolumeKeyEventBeforeJellyBean(event)
+        return castContext.onDispatchVolumeKeyEventBeforeJellyBean(event)
                 || super.dispatchKeyEvent(event);
     }
 
     @Override
     protected void onResume() {
-        mCastContext.getSessionManager().addSessionManagerListener(
-                mSessionManagerListener, CastSession.class);
-        if (mRemoteMediaClient == null) {
-            mRemoteMediaClient = getRemoteMediaClient();
+        castContext.getSessionManager().addSessionManagerListener(
+                sessionManagerListener, CastSession.class);
+        if (remoteMediaClient == null) {
+            remoteMediaClient = getRemoteMediaClient();
         }
-        if (mRemoteMediaClient != null) {
-            mRemoteMediaClient.addListener(mRemoteMediaClientListener);
-            MediaStatus mediaStatus = mRemoteMediaClient.getMediaStatus();
+        if (remoteMediaClient != null) {
+            remoteMediaClient.addListener(remoteMediaClientListener);
+            MediaStatus mediaStatus = remoteMediaClient.getMediaStatus();
             List<MediaQueueItem> queueItems =
                     (mediaStatus == null) ? null : mediaStatus.getQueueItems();
             if (queueItems != null && !queueItems.isEmpty()) {
-                mEmptyView.setVisibility(View.GONE);
+                emptyView.setVisibility(View.GONE);
             }
         }
         super.onResume();
     }
 
     private RemoteMediaClient getRemoteMediaClient() {
-        CastSession castSession = mCastContext.getSessionManager().getCurrentCastSession();
+        CastSession castSession = castContext.getSessionManager().getCurrentCastSession();
         return (castSession != null && castSession.isConnected())
                 ? castSession.getRemoteMediaClient() : null;
     }

--- a/src/com/google/sample/cast/refplayer/queue/ui/QueueListViewFragment.java
+++ b/src/com/google/sample/cast/refplayer/queue/ui/QueueListViewFragment.java
@@ -44,8 +44,8 @@ public class QueueListViewFragment extends Fragment
         implements QueueListAdapter.OnStartDragListener {
 
     private static final String TAG = "QueueListViewFragment";
-    private QueueDataProvider mProvider;
-    private ItemTouchHelper mItemTouchHelper;
+    private QueueDataProvider provider;
+    private ItemTouchHelper itemTouchHelper;
 
     public QueueListViewFragment() {
         super();
@@ -59,14 +59,14 @@ public class QueueListViewFragment extends Fragment
 
     @Override
     public void onStartDrag(RecyclerView.ViewHolder viewHolder) {
-        mItemTouchHelper.startDrag(viewHolder);
+        itemTouchHelper.startDrag(viewHolder);
     }
 
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         RecyclerView recyclerView = (RecyclerView) getView().findViewById(R.id.recycler_view);
-        mProvider = QueueDataProvider.getInstance(getContext());
+        provider = QueueDataProvider.getInstance(getContext());
 
         QueueListAdapter adapter = new QueueListAdapter(getActivity(), this);
         recyclerView.setHasFixedSize(true);
@@ -74,8 +74,8 @@ public class QueueListViewFragment extends Fragment
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
 
         ItemTouchHelper.Callback callback = new QueueItemTouchHelperCallback(adapter);
-        mItemTouchHelper = new ItemTouchHelper(callback);
-        mItemTouchHelper.attachToRecyclerView(recyclerView);
+        itemTouchHelper = new ItemTouchHelper(callback);
+        itemTouchHelper.attachToRecyclerView(recyclerView);
 
         adapter.setEventListener(new QueueListAdapter.EventListener() {
             @Override
@@ -92,11 +92,11 @@ public class QueueListViewFragment extends Fragment
                         onPlayPauseClicked(view);
                         break;
                     case R.id.play_upcoming:
-                        mProvider.onUpcomingPlayClicked(view,
+                        provider.onUpcomingPlayClicked(view,
                                 (MediaQueueItem) view.getTag(R.string.queue_tag_item));
                         break;
                     case R.id.stop_upcoming:
-                        mProvider.onUpcomingStopClicked(view,
+                        provider.onUpcomingStopClicked(view,
                                 (MediaQueueItem) view.getTag(R.string.queue_tag_item));
                         break;
                 }
@@ -117,15 +117,15 @@ public class QueueListViewFragment extends Fragment
             return;
         }
         MediaQueueItem item = (MediaQueueItem) view.getTag(R.string.queue_tag_item);
-        if (mProvider.isQueueDetached()) {
+        if (provider.isQueueDetached()) {
             Log.d(TAG, "Is detached: itemId = " + item.getItemId());
 
-            int currentPosition = mProvider.getPositionByItemId(item.getItemId());
-            MediaQueueItem[] items = Utils.rebuildQueue(mProvider.getItems());
+            int currentPosition = provider.getPositionByItemId(item.getItemId());
+            MediaQueueItem[] items = Utils.rebuildQueue(provider.getItems());
             remoteMediaClient.queueLoad(items, currentPosition,
                     MediaStatus.REPEAT_MODE_REPEAT_OFF, null);
         } else {
-            int currentItemId = mProvider.getCurrentItemId();
+            int currentItemId = provider.getCurrentItemId();
             if (currentItemId == item.getItemId()) {
                 // We selected the one that is currently playing so we take the user to the
                 // full screen controller


### PR DESCRIPTION
This solves #37 adding consistency and modern way of naming variables. Second commit explains why CastOptionsProvider.java is marked as unused to a user getting started with the framework.